### PR TITLE
Feature/json logger

### DIFF
--- a/{{ cookiecutter.project_slug }}/requirements/dist.txt
+++ b/{{ cookiecutter.project_slug }}/requirements/dist.txt
@@ -2,3 +2,4 @@
 gunicorn==20.0.4
 # sentry-sdk==0.14.4
 # whitenoise==5.1.0
+python-json-logger==0.1.11

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/common/formatters.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/common/formatters.py
@@ -1,0 +1,14 @@
+from pythonjsonlogger import jsonlogger
+
+
+class DjangoRequestJsonFormatter(jsonlogger.JsonFormatter):
+    def add_fields(self, log_record, record, message_dict):
+        if getattr(record, 'request', None):
+            if getattr(record.request, 'method', None):
+                record.request = {
+                    'request': record.request,
+                    'headers': record.request.headers,
+                    'body': record.request.body.decode('UTF-8')
+                }
+
+        super().add_fields(log_record, record, message_dict)

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/common/formatters.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/common/formatters.py
@@ -2,9 +2,20 @@ from pythonjsonlogger import jsonlogger
 
 
 class DjangoRequestJsonFormatter(jsonlogger.JsonFormatter):
+    """
+    This class is used to serialize headers and body of the JSON Django request
+    into the `request` property in the record of `jsonlogger.JsonFormatter`.
+    """
+
     def add_fields(self, log_record, record, message_dict):
         if getattr(record, 'request', None):
-            if getattr(record.request, 'method', None):
+            def is_django_request(request):
+                return getattr(record.request, 'method', None)
+
+            def is_json_request(request):
+                return record.request.META.get('CONTENT_TYPE', None) == 'application/json'
+
+            if is_django_request(record.request) and is_json_request(record.request):
                 record.request = {
                     'request': record.request,
                     'headers': record.request.headers,

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/common/formatters.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/common/formatters.py
@@ -12,18 +12,19 @@ class DjangoRequestJsonFormatter(jsonlogger.JsonFormatter):
             def is_django_request(request):
                 return getattr(record.request, 'method', None)
 
-            def is_json_request(request):
-                return record.request.META.get('CONTENT_TYPE', None) == 'application/json'
+            def has_correct_content_type(request):
+                CONTENT_TYPES = ['application/json', 'application/x-www-form-urlencoded']
+                return record.request.META.get('CONTENT_TYPE', None) in CONTENT_TYPES
 
-            if is_django_request(record.request) and is_json_request(record.request):
-                is_json_request = is_json_request(record.request)
+            if is_django_request(record.request):
+                has_correct_content_type = has_correct_content_type(record.request)
 
                 record.request = {
                     'request': record.request,
-                    'headers': record.request.headers,
+                    'headers': record.request.headers
                 }
 
-                if is_json_request:
-                    request.record['body'] = record.request.body.decode('UTF-8')
+                if has_correct_content_type:
+                    record.request['body'] = record.request['request'].body.decode('UTF-8')
 
         super().add_fields(log_record, record, message_dict)

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/common/formatters.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/apps/common/formatters.py
@@ -16,10 +16,14 @@ class DjangoRequestJsonFormatter(jsonlogger.JsonFormatter):
                 return record.request.META.get('CONTENT_TYPE', None) == 'application/json'
 
             if is_django_request(record.request) and is_json_request(record.request):
+                is_json_request = is_json_request(record.request)
+
                 record.request = {
                     'request': record.request,
                     'headers': record.request.headers,
-                    'body': record.request.body.decode('UTF-8')
                 }
+
+                if is_json_request:
+                    request.record['body'] = record.request.body.decode('UTF-8')
 
         super().add_fields(log_record, record, message_dict)

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/dist.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/dist.py
@@ -26,7 +26,7 @@ LOGGING = {
         },
         'json_formatter': {
             'class': '{{ cookiecutter.project_slug }}.apps.common.formatters.DjangoRequestJsonFormatter',
-            'format': '%(levelname)s %(module)s %(process)d %(thread)d %(message)s'
+            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
         },
     },
     'handlers': {
@@ -39,7 +39,7 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'
         },
-        'json': {
+        'console_json': {
             'class': 'logging.StreamHandler',
             'formatter': 'json_formatter'
         }
@@ -47,10 +47,10 @@ LOGGING = {
     'loggers': {
         'apps': {
             "level": "DEBUG",
-            "handlers": ["json"],
+            "handlers": ["console_json"],
         },
         'django': {
-            'handlers': ["json"],
+            'handlers': ["console_json"],
             'level': 'INFO',
             'propagate': True,
         },

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/dist.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings/dist.py
@@ -24,6 +24,10 @@ LOGGING = {
         'simple': {
             'format': '%(levelname)s %(message)s'
         },
+        'json_formatter': {
+            'class': '{{ cookiecutter.project_slug }}.apps.common.formatters.DjangoRequestJsonFormatter',
+            'format': '%(levelname)s %(module)s %(process)d %(thread)d %(message)s'
+        },
     },
     'handlers': {
         'mail_admins': {
@@ -35,14 +39,18 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'
         },
+        'json': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'json_formatter'
+        }
     },
     'loggers': {
         'apps': {
             "level": "DEBUG",
-            "handlers": ["console"],
+            "handlers": ["json"],
         },
         'django': {
-            'handlers': ["console"],
+            'handlers': ["json"],
             'level': 'INFO',
             'propagate': True,
         },


### PR DESCRIPTION
This pull requests adds support for requests json logging.

Some examples from console
```json
{
    "message": "Forbidden (CSRF cookie not set.): /test/", 
    "status_code": 403, 
    "request": {
        "request": "<WSGIRequest: POST '/test/'>",
        "headers": "{'Content-Length': '23', ...}",
        "body": "{\n    \"query\": \"test\"\n}"
    }
    ...
}

{
    "message": "Internal Server Error: /test/",
    "exc_info": "...",
    "status_code": 500,
    "request": {
        "request": "<WSGIRequest: GET '/test/'>",
        "headers": "{'Content-Length': '', ...}",
        "body": ""
    }
    ...
}
```